### PR TITLE
added a generator to data.random_split to make data splits consistent

### DIFF
--- a/datasets/dataset_loading_hub.py
+++ b/datasets/dataset_loading_hub.py
@@ -32,7 +32,7 @@ class MNISTLoader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
+    def get_data(self, data_filepath, val_set_percentage, random_split_seed, download=False):
         train_set = datasets.MNIST(
             data_filepath, train=True, download=download, transform=self.transform_train
         )
@@ -121,7 +121,7 @@ class CIFAR10Loader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
+    def get_data(self, data_filepath, val_set_percentage, random_split_seed, download=False):
         train_set = datasets.CIFAR10(
             root=data_filepath,
             train=True,
@@ -170,7 +170,7 @@ class CIFAR100Loader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
+    def get_data(self, data_filepath, val_set_percentage, random_split_seed, download=False):
         train_set = datasets.CIFAR100(
             root=data_filepath,
             train=True,
@@ -221,7 +221,7 @@ class ImageNetLoader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, random_split_seed=1, **kwargs):
+    def get_data(self, data_filepath, val_set_percentage, random_split_seed, **kwargs):
         train_dir = os.path.join(data_filepath, "train")
         val_dir = os.path.join(data_filepath, "val")
 
@@ -250,6 +250,7 @@ def load_dataset(
     num_workers=0,
     download=False,
     val_set_percentage=0.0,
+    random_split_seed=1
 ):
 
     datasets = {
@@ -267,7 +268,8 @@ def load_dataset(
     ###
 
     train_set, val_set, test_set, num_labels = dataloader.get_data(
-        data_filepath, val_set_percentage=val_set_percentage, download=download
+        data_filepath, val_set_percentage=val_set_percentage, 
+        random_split_seed=random_split_seed, download=download,
     )
 
     train_loader = torch.utils.data.DataLoader(

--- a/datasets/dataset_loading_hub.py
+++ b/datasets/dataset_loading_hub.py
@@ -40,7 +40,8 @@ class MNISTLoader:
         num_val_items = len(train_set) - num_training_items
 
         train_set, val_set = torch.utils.data.random_split(
-            train_set, [num_training_items, num_val_items]
+            train_set, [num_training_items, num_val_items],
+            generator=torch.Generator().manual_seed(1)
         )
 
         test_set = datasets.MNIST(
@@ -132,7 +133,8 @@ class CIFAR10Loader:
         num_val_items = len(train_set) - num_training_items
 
         train_set, val_set = torch.utils.data.random_split(
-            train_set, [num_training_items, num_val_items]
+            train_set, [num_training_items, num_val_items],
+            generator=torch.Generator().manual_seed(1)
         )
 
         test_set = datasets.CIFAR10(
@@ -180,7 +182,8 @@ class CIFAR100Loader:
         num_val_items = len(train_set) - num_training_items
 
         train_set, val_set = torch.utils.data.random_split(
-            train_set, [num_training_items, num_val_items]
+            train_set, [num_training_items, num_val_items],
+            generator=torch.Generator().manual_seed(1)
         )
 
         test_set = datasets.CIFAR100(
@@ -228,7 +231,8 @@ class ImageNetLoader:
         num_val_items = len(train_set) - num_training_items
 
         train_set, val_set = torch.utils.data.random_split(
-            train_set, [num_training_items, num_val_items]
+            train_set, [num_training_items, num_val_items],
+            generator=torch.Generator().manual_seed(1)
         )
 
         test_set = datasets.ImageFolder(val_dir, self.transform_validate)

--- a/datasets/dataset_loading_hub.py
+++ b/datasets/dataset_loading_hub.py
@@ -32,7 +32,7 @@ class MNISTLoader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False):
+    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
         train_set = datasets.MNIST(
             data_filepath, train=True, download=download, transform=self.transform_train
         )
@@ -41,7 +41,7 @@ class MNISTLoader:
 
         train_set, val_set = torch.utils.data.random_split(
             train_set, [num_training_items, num_val_items],
-            generator=torch.Generator().manual_seed(1)
+            generator=torch.Generator().manual_seed(random_split_seed)
         )
 
         test_set = datasets.MNIST(
@@ -121,7 +121,7 @@ class CIFAR10Loader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False):
+    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
         train_set = datasets.CIFAR10(
             root=data_filepath,
             train=True,
@@ -134,7 +134,7 @@ class CIFAR10Loader:
 
         train_set, val_set = torch.utils.data.random_split(
             train_set, [num_training_items, num_val_items],
-            generator=torch.Generator().manual_seed(1)
+            generator=torch.Generator().manual_seed(random_split_seed)
         )
 
         test_set = datasets.CIFAR10(
@@ -170,7 +170,7 @@ class CIFAR100Loader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, download=False):
+    def get_data(self, data_filepath, val_set_percentage, download=False, random_split_seed=1):
         train_set = datasets.CIFAR100(
             root=data_filepath,
             train=True,
@@ -183,7 +183,7 @@ class CIFAR100Loader:
 
         train_set, val_set = torch.utils.data.random_split(
             train_set, [num_training_items, num_val_items],
-            generator=torch.Generator().manual_seed(1)
+            generator=torch.Generator().manual_seed(random_split_seed)
         )
 
         test_set = datasets.CIFAR100(
@@ -221,7 +221,7 @@ class ImageNetLoader:
             ]
         )
 
-    def get_data(self, data_filepath, val_set_percentage, **kwargs):
+    def get_data(self, data_filepath, val_set_percentage, random_split_seed=1, **kwargs):
         train_dir = os.path.join(data_filepath, "train")
         val_dir = os.path.join(data_filepath, "val")
 
@@ -232,7 +232,7 @@ class ImageNetLoader:
 
         train_set, val_set = torch.utils.data.random_split(
             train_set, [num_training_items, num_val_items],
-            generator=torch.Generator().manual_seed(1)
+            generator=torch.Generator().manual_seed(random_split_seed)
         )
 
         test_set = datasets.ImageFolder(val_dir, self.transform_validate)


### PR DESCRIPTION
I added a generator (manual seed) to data.random_split to make data splits consistent across seeds. Previously the training and validation splits were different for each seed causing data leakage and irreproducibility. Documentation: https://pytorch.org/docs/stable/data.html#torch.utils.data.random_split 